### PR TITLE
Ensure oneagent starts before regular bosh jobs start

### DIFF
--- a/jobs/dynatrace-oneagent/spec
+++ b/jobs/dynatrace-oneagent/spec
@@ -4,6 +4,7 @@ description: "This is a job that will run Dynatrace OneAgent installer for Linux
 
 templates:
   dynatrace-oneagent.sh.erb: bin/dynatrace-oneagent.sh
+  pre-start.erb: bin/pre-start
 
 packages:
 

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/var/vcap/jobs/dynatrace-oneagent/bin/dynatrace-oneagent.sh start


### PR DESCRIPTION
pre-start is executed before regular start scripts.
Therefore, the oneagent is started before any other
regular bosh jobs are started. This way, no restart
of bosh jobs is necessary to ensure they're
monitored by the oneagent.

For most releases, this is probably what you want.