### PR TITLE
Tests for BOSH Release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'bosh-template'
+  gem 'rspec'
+  gem 'rspec-bash'
+end

--- a/jobs/dynatrace-oneagent/templates/pre-start.erb
+++ b/jobs/dynatrace-oneagent/templates/pre-start.erb
@@ -2,19 +2,24 @@
 
 export PATH="/var/vcap/packages/dynatrace-oneagent:$PATH"
 
-export DOWNLOADURL="<%= properties.dynatrace.downloadurl %>"
-export PROXY="<%= properties.dynatrace.proxy %>"
-export ENV_ID="<%= properties.dynatrace.environmentid %>"
-export API_TOKEN="<%= properties.dynatrace.apitoken %>"
-export API_URL="<%= properties.dynatrace.apiurl %>"
-export SSL_MODE="<%= properties.dynatrace.sslmode %>"
-export APP_LOG_CONTENT_ACCESS="<%= properties.dynatrace.applogaccess %>"
+export DOWNLOADURL="<%= p("dynatrace.downloadurl") %>"
+export PROXY="<%= p("dynatrace.proxy") %>"
+export ENV_ID="<%= p("dynatrace.environmentid") %>"
+export API_TOKEN="<%= p("dynatrace.apitoken") %>"
+export API_URL="<%= p("dynatrace.apiurl") %>"
+export SSL_MODE="<%= p("dynatrace.sslmode") %>"
+export APP_LOG_CONTENT_ACCESS="<%= p("dynatrace.applogaccess") %>"
 
 export TMPDIR="/var/vcap/data/dt_tmp"
 
 RUN_DIR="/var/vcap/sys/run/dynatrace-oneagent"
 LOG_DIR="/var/vcap/sys/log/dynatrace-oneagent"
 LOG_FILE="$LOG_DIR/dynatrace-install.log"
+
+installLog() {
+    echo "$1" | tee -a "${LOG_FILE}"
+}
+
 if ! mkdir -p "${RUN_DIR}" "${LOG_DIR}"; then
     installLog "ERROR: Creating directories ${RUN_DIR} and ${LOG_DIR} failed!"
     exit 1
@@ -141,10 +146,6 @@ runInstaller() {
         fi
 
     done
-}
-
-installLog() {
-    echo "$1" | tee -a "${LOG_FILE}"
 }
 
 # Installation process starts here

--- a/spec/jobs/dynatrace-oneagent_spec.rb
+++ b/spec/jobs/dynatrace-oneagent_spec.rb
@@ -1,0 +1,229 @@
+require 'json'
+require 'rspec'
+require 'rspec/bash'
+require 'bosh/template/test'
+require 'pathname'
+require 'fileutils'
+
+
+describe 'dynatrace release' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../..')) }
+  let(:stubbed_env) { Rspec::Bash::StubbedEnv.new(Rspec::Bash::StubbedEnv::BASH_STUB) }
+
+  describe 'dynatrace-oneagent job' do
+    let(:job) { release.job('dynatrace-oneagent') }
+
+    describe 'pre-start' do
+      let(:template) { job.template('bin/pre-start') }
+
+      describe 'render' do
+        let(:manifest) do
+          {
+            'dynatrace' => {
+              'environmentid' => 'environmentid',
+              'apitoken' => 'apitoken'
+            }
+          }
+        end
+
+        it 'render' do
+          script = template.render(manifest)
+
+          expect(script).to match('^export DOWNLOADURL=""$')
+          expect(script).to match('^export PROXY=""$')
+          expect(script).to match('^export ENV_ID="environmentid"$')
+          expect(script).to match('^export API_TOKEN="apitoken"$')
+          expect(script).to match('^export API_URL=""$')
+          expect(script).to match('^export SSL_MODE=""$')
+          expect(script).to match('^export APP_LOG_CONTENT_ACCESS="1"$')
+        end
+      end
+
+      describe 'install base dir #1' do
+        describe 'test directory exists' do
+          let(:manifest) do
+            {
+              'dynatrace' => {
+                'environmentid' => 'environmentid',
+                'apitoken' => 'apitoken'
+              }
+            }
+          end
+          it 'test' do
+            script = template.render(manifest)
+            stdout, stderr, status = stubbed_env.execute_inline(script)
+            expect(stdout).to match("Not enough disk space available on /var/vcap/data!")
+            expect(status.exitstatus).to eq 1
+          end
+        end
+        describe 'create install base dir' do
+          it 'make path', :install => true do
+            FileUtils.mkpath('/var/vcap/data')
+          end
+        end
+      end
+
+      describe 'custom urls' do
+        describe 'downloadurl' do
+          let(:manifest) do
+            {
+              'dynatrace' => {
+                'downloadurl' => 'downloadurl',
+                'environmentid' => '',
+                'apitoken' => ''
+              }
+            }
+          end
+          it 'exec' do
+            script = template.render(manifest)
+            stdout, stderr, status = stubbed_env.execute_inline(script)
+            expect(stdout).to match(/Downloading agent installer from downloadurl/)
+            expect(stdout).to match(/Dynatrace agent download failed, retrying in /)
+            expect(stdout).to match(/ERROR: Downloading agent installer failed!/)
+            expect(status.exitstatus).to eq 1
+          end
+        end
+        describe 'apiurl' do
+          let(:manifest) do
+            {
+              'dynatrace' => {
+                'apiurl' => 'apiurl',
+                'environmentid' => 'na',
+                'apitoken' => 'na'
+              }
+            }
+          end
+          it 'exec' do
+            script = template.render(manifest)
+            stdout, stderr, status = stubbed_env.execute_inline(script)
+            expect(stdout).to include("Downloading agent installer from apiurl/v1/deployment/installer/agent/unix/default/latest?Api-Token=na")
+            expect(stdout).to match(/ERROR: Downloading agent installer failed!/)
+            expect(status.exitstatus).to eq 1
+          end
+        end
+      end
+
+      describe 'invalid configuration' do
+        describe 'no environmentid' do
+          let(:manifest) do
+            {
+              'dynatrace' => {
+                'environmentid' => '',
+                'apitoken' => 'apitoken'
+              }
+            }
+          end
+          it 'exec' do
+            script = template.render(manifest)
+            stdout, stderr, status = stubbed_env.execute_inline(script)
+            expect(status.exitstatus).to eq 1
+            expect(stdout).to match(/Please set environment ID and API token for Dynatrace OneAgent./)
+          end
+        end
+        describe 'no apitoken' do
+          let(:manifest) do
+            {
+              'dynatrace' => {
+                'environmentid' => 'environmentid',
+                'apitoken' => ''
+              }
+            }
+          end
+          it 'exec' do
+            script = template.render(manifest)
+            stdout, stderr, status = stubbed_env.execute_inline(script)
+            expect(status.exitstatus).to eq 1
+            expect(stdout).to match(/Please set environment ID and API token for Dynatrace OneAgent./)
+          end
+        end
+        describe 'no environmentid,apitoken' do
+          let(:manifest) do
+            {
+              'dynatrace' => {
+                'environmentid' => '',
+                'apitoken' => ''
+              }
+            }
+          end
+          it 'exec' do
+            script = template.render(manifest)
+            stdout, stderr, status = stubbed_env.execute_inline(script)
+            expect(status.exitstatus).to eq 1
+            expect(stdout).to match(/Please set environment ID and API token for Dynatrace OneAgent./)
+          end
+        end
+      end
+
+      describe 'install' do
+        let(:manifest) do
+          {
+            'dynatrace' => {
+              'environmentid' => ENV["DT_TENANT"],
+              'apitoken' => ENV["DT_API_TOKEN"],
+              'apiurl' => ENV["DT_API_URL"]
+            }
+          }
+        end
+        it 'parameter test' do
+          expect(ENV).to have_key("DT_TENANT")
+          expect(ENV).to have_key("DT_API_TOKEN")
+          expect(ENV).to have_key("DT_API_URL")
+        end
+        it 'exec', :install => true do
+          script = template.render(manifest)
+          stdout, stderr, status = stubbed_env.execute_inline(script)
+          expect(stdout).to match(/Installation finished/)
+          expect(stdout).to_not match(/Error/)
+          expect(status.exitstatus).to eq 0
+          expect(FileTest.exist?('/var/vcap/sys/run/dynatrace-oneagent/dynatrace-watchdog.pid')).to be true
+        end
+      end
+
+    end
+
+    describe 'stop-oneagent.sh', :monit => true do
+      let(:template) { job.template('bin/stop-oneagent.sh') }
+      let(:manifest) {}
+      it 'exec' do
+        script = template.render(manifest)
+        stdout, stderr, status = stubbed_env.execute_inline(script)
+        expect(status.exitstatus).to eq 0
+      end
+    end
+
+
+    describe 'start-oneagent.sh', :monit => true do
+      let(:template) { job.template('bin/start-oneagent.sh') }
+      let(:manifest) {}
+      it 'exec' do
+        script = template.render(manifest)
+        stdout, stderr, status = stubbed_env.execute_inline(script)
+        expect(status.exitstatus).to eq 0
+      end
+    end
+
+
+    describe 'drain' do
+      let(:template) { job.template('bin/drain') }
+      describe 'exec', :uninstall => true do
+        let(:manifest) {}
+        it 'exec' do
+          script = template.render(manifest)
+          stdout, stderr, status = stubbed_env.execute_inline(script)
+          expect(status.exitstatus).to eq 0
+          expect(stdout).to eq("0\n")
+        end
+      end
+
+      describe 'install base dir #2' do
+        describe 'remove install base dir' do
+          it 'remove path', :uninstall => true do
+            FileUtils.remove_entry_secure('/var/vcap/data')
+          end
+        end
+      end
+    end
+
+
+  end
+end


### PR DESCRIPTION
* Rspec based tests for BOSH Release.
* Use operator p() from BOSH::Template for property replacement.
* Move installLog() to top of script in order to be compatible with rspec.